### PR TITLE
AHC-1150 wait time display

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -9,7 +9,3 @@ AllCops:
 Style/MixinUsage:
   Exclude:
     - 'bin/**'
-
-Style/TrailingCommaInLiteral:
-  Exclude:
-    - '*/**'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,14 @@
 # Change Log
 
-## [?.?.8] - 2019-03-29
+## [?.?.?] - 2019-03-29
 ### ahc-sprint-20
 ### Added
   - db:seed now creates default admin user
+### Changed
+  - AHC-1150
+    - Added icons inline with service wait time estimate values, handle unknown wait time
 
-## [?.?.?] - 2019-03-08
+## [?.?.?] - 2019-03-15
 ### ahc-sprint-19
 ### Added
  - AHC-1068

--- a/app/assets/stylesheets/components/_service-wait.scss
+++ b/app/assets/stylesheets/components/_service-wait.scss
@@ -1,0 +1,35 @@
+// Service wait time estimate section
+  .inline-icon-text {
+    position: relative;
+    display: inline-block;
+    .fa {
+      position: absolute;
+      width: $font_size_110;
+      font-size: #{$font_size_105 + 2};
+      text-align: center;
+      @include box-sizing(border-box);
+      line-height: #{$font_size_105 + 3};
+    }
+    .short-wait {
+      color: #FFC426;
+    }
+    .available{
+      color: #BBCC33;
+    }
+    .long-wait{
+      color: #FDA549;
+    }
+    .unknown{
+      color: #FFC426;
+    }
+
+    > span {
+      display: inline-block;
+      margin-left: #{$font_size_110 + 5};
+      font-family: $font_san_serif;
+      @include box-sizing(border-box);
+      line-height: #{$font_size_105 + 4};
+      @include inline-block();
+      vertical-align: top;
+    }
+  }

--- a/app/views/component/detail/_service_wait.html.haml
+++ b/app/views/component/detail/_service_wait.html.haml
@@ -1,5 +1,14 @@
-- if user_signed_in? && service.wait_time.present?
+- if user_signed_in?
   %section.wait-time
-    %h1= t('service_fields.wait_time')
-    %span
-      = service.wait_time
+    %h1= t('service_fields.availability.service_wait_estimate')
+    %section.inline-icon-text
+      - if service&.wait_time == 'Available Today'
+        %i.fa.fa-check-circle-o.available
+      - elsif service&.wait_time == '2-3 Day Wait'
+        %i.fa.fa-clock-o.short-wait
+      - elsif service&.wait_time == '1 Week Wait'
+        %i.fa.fa-times-circle-o.long-wait
+      - else
+        %i.fa.fa-question-circle-o.unknown
+      %span
+        = service.wait_time || t('service_fields.availability.unknown')

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -110,7 +110,9 @@ en:
     status_defunct: 'This service is no longer operating!'
     status_inactive: 'This service is not currently operating!'
     urls: 'Homepage:'
-    wait_time: 'Service Wait Estimate:'
+    availability:
+      service_wait_estimate: 'Service Wait Estimate:'
+      unknown: 'Call for availability'
 
   time:
     formats:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -7,7 +7,7 @@ Rails.application.routes.draw do
 
   root to: 'home#index'
   devise_for :users, controllers: {
-    registrations: 'users/registrations',
+    registrations: 'users/registrations'
   }
   resources :locations, only: [:index]
   get 'locations/*id/' => 'locations#show', as: 'location'

--- a/spec/factories/service.rb
+++ b/spec/factories/service.rb
@@ -1,0 +1,33 @@
+class Service
+  attr_accessor :id, :accepted_payments, :alternate_name, :audience, :description, :eligibility,
+                :email, :fees, :funding_sources, :application_process, :interpretation_services,
+                :keywords, :languages, :name, :required_documents, :service_areas, :status, :website,
+                :wait_time
+end
+
+FactoryBot.define do
+  factory :service do
+    id { (1..100).to_a.sample }
+    accepted_payments { %w[Cash Check Credit\ Card] }
+    alternate_name { Faker::Pokemon.name }
+    audience { 'Adult alcoholic/drug addictive men and women with social and spiritual problems' }
+    description do
+      'Provides a long-term (6-12 month) residential rehabilitation program for men and women with
+      substance abuse and other problems. Residents receive individual counseling, and drug and alcohol education.'
+    end
+    eligibility { 'Age 21-60, detoxed, physically able and willing to participate in a work therapy program' }
+    email { Faker::Internet.email }
+    fees { 'None' }
+    funding_sources { %w[donations sales] }
+    application_process { 'Walk in or through other agency referral' }
+    interpretation_services { 'We offer 3-way interpretation services over the phone via Propio Language Services (http://propio-ls.com).' }
+    keywords { %W[#{Faker::Superhero.power} #{Faker::Superhero.power}] }
+    languages { %w[English Spanish] }
+    name { Faker::Pokemon.name }
+    required_documents { ['Government-issued picture identification'] }
+    service_areas { %w[Alameda\ County San\ Mateo\ County] }
+    status { 'active' }
+    website { 'http://www.example.com' }
+    wait_time { 'Available Today' }
+  end
+end

--- a/spec/views/component/detail/_service_wait_spec.rb
+++ b/spec/views/component/detail/_service_wait_spec.rb
@@ -17,7 +17,51 @@ RSpec.describe 'component/detail/service_wait' do
     expect(rendered).to have_selector('.fa.fa-check-circle-o.available')
   end
 
-  it 'will show the correct wait time' do
-    expect(rendered).to have_content('Available Today')
+  context "when the wait time is 'Available Today'" do
+    let(:service) { build(:service, wait_time: 'Available Today') }
+
+    before do
+      render 'component/detail/service_wait', service: service
+    end
+
+    it 'will show the correct wait time' do
+      expect(rendered).to have_content('Available Today')
+    end
+  end
+
+  context "when the wait time is '2-3 Day Wait'" do
+    let(:service) { build(:service, wait_time: '2-3 Day Wait') }
+
+    before do
+      render 'component/detail/service_wait', service: service
+    end
+
+    it 'will show the correct wait time' do
+      expect(rendered).to have_content('2-3 Day Wait')
+    end
+  end
+
+  context "when the wait time is '1 Week Wait'" do
+    let(:service) { build(:service, wait_time: '1 Week Wait') }
+
+    before do
+      render 'component/detail/service_wait', service: service
+    end
+
+    it 'will show the correct wait time' do
+      expect(rendered).to have_content('1 Week Wait')
+    end
+  end
+
+  context "when the wait time is 'Unknown'" do
+    let(:service) { build(:service, wait_time: 'Unknown') }
+
+    before do
+      render 'component/detail/service_wait', service: service
+    end
+
+    it 'will show the correct wait time' do
+      expect(rendered).to have_content('Unknown')
+    end
   end
 end

--- a/spec/views/component/detail/_service_wait_spec.rb
+++ b/spec/views/component/detail/_service_wait_spec.rb
@@ -1,0 +1,23 @@
+require 'rails_helper'
+
+RSpec.describe 'component/detail/service_wait' do
+  let(:service) { build(:service) }
+  let(:user) { build(:user) }
+
+  before do
+    allow(view).to receive(:user_signed_in?) { true }
+    render 'component/detail/service_wait', service: service
+  end
+
+  it 'will show the wait time estimate label' do
+    expect(rendered).to have_content(t('service_fields.availability.service_wait_estimate'))
+  end
+
+  it 'will show the correct icon' do
+    expect(rendered).to have_selector('.fa.fa-check-circle-o.available')
+  end
+
+  it 'will show the correct wait time' do
+    expect(rendered).to have_content('Available Today')
+  end
+end


### PR DESCRIPTION
First, visit a service location's page (e.g. http://localhost:3000/locations/salvation-army/adult-rehabilitation-center?keyword=Rehabilitation&location=&org_name=Salvation+Army)

See https://github.com/FearlessSolutions/bahc-ohana-api/pull/9 to help verify that the `Service Wait Estimate` field on a service page in the Ohana UI is updated, with corresponding icons, according to the database information.