### PR TITLE
AHC-1280 Add Next Day Service wait time label

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Change Log
 
+## [?.?.?] - 2019-04-12
+### ahc-sprint-21
+### Changed
+  - AHC-1280
+    - Added `Next Day Service` wait time label and icon
+    - Changed colors for existing wait time icons
+       
 ## [?.?.?] - 2019-03-29
 ### ahc-sprint-20
 ### Added

--- a/app/assets/stylesheets/components/_service-wait.scss
+++ b/app/assets/stylesheets/components/_service-wait.scss
@@ -10,17 +10,20 @@
       @include box-sizing(border-box);
       line-height: #{$font_size_105 + 3};
     }
-    .short-wait {
-      color: #FFC426;
-    }
     .available{
       color: #BBCC33;
     }
-    .long-wait{
+    .next-day {
+      color: #FFC427
+    }
+    .short-wait {
       color: #FDA549;
     }
+    .long-wait{
+      color: #C1484C;
+    }
     .unknown{
-      color: #FFC426;
+      color: #06A0B8;
     }
 
     > span {

--- a/app/views/component/detail/_service_wait.html.haml
+++ b/app/views/component/detail/_service_wait.html.haml
@@ -4,6 +4,8 @@
     %section.inline-icon-text
       - if service&.wait_time == 'Available Today'
         %i.fa.fa-check-circle-o.available
+      - elsif service&.wait_time == 'Next Day Service'
+        %i.fa.fa-chevron-circle-right.next-day
       - elsif service&.wait_time == '2-3 Day Wait'
         %i.fa.fa-clock-o.short-wait
       - elsif service&.wait_time == '1 Week Wait'

--- a/spec/views/component/detail/_service_wait_spec.rb
+++ b/spec/views/component/detail/_service_wait_spec.rb
@@ -29,6 +29,18 @@ RSpec.describe 'component/detail/service_wait' do
     end
   end
 
+  context "when the wait time is 'Next Day Service'" do
+    let(:service) { build(:service, wait_time: 'Next Day Service') }
+
+    before do
+      render 'component/detail/service_wait', service: service
+    end
+
+    it 'will show the correct wait time' do
+      expect(rendered).to have_content('Next Day Service')
+    end
+  end
+
   context "when the wait time is '2-3 Day Wait'" do
     let(:service) { build(:service, wait_time: '2-3 Day Wait') }
 


### PR DESCRIPTION
Check out the branch from the other pull request and choose the `Next Day Service` wait time here:
http://lvh.me:8080/admin/locations/adult-rehabilitation-center/services/15


Then, for this pull request, we want to make sure the new `Next Day Service` label is present with its new icon:
http://localhost:3000/locations/salvation-army/adult-rehabilitation-center?keyword=Rehabilitation&location=&org_name=Salvation+Army&utf8=%E2%9C%93