### PR TITLE
Add Service website to Service information on Locations

### DIFF
--- a/app/views/component/detail/_service_website.html.haml
+++ b/app/views/component/detail/_service_website.html.haml
@@ -1,0 +1,9 @@
+-# The website partial displays the website icon and address.
+  e.g. [icon] www.example.com
+
+- if service.website.present?
+  %section.website.icon-text-block
+    %i.fa.fa-external-link-square
+    %span.annotated-text-block
+      %a{ href: service.website, target: '_blank', itemprop: 'url' }
+        = format_url(service.website)

--- a/app/views/component/locations/detail/_body.html.haml
+++ b/app/views/component/locations/detail/_body.html.haml
@@ -150,6 +150,7 @@
             = render 'component/detail/service_service_areas', service: service
             = render 'component/detail/service_situations', service: service
             = render 'component/detail/service_categories', service: service
+            = render 'component/detail/service_website', service: service
 
 
     / Detail footer content.


### PR DESCRIPTION
- service_website file in the view
- render file in location detail body

**Zube card**: 103

**Github issue**: https://github.com/bchd/bahc-ohana-api/issues/94