### PR TITLE
Zube Tickets 204 and 205 modify homepage to add Categories as a drop down menu

### DIFF
--- a/app/assets/stylesheets/components/_box.scss
+++ b/app/assets/stylesheets/components/_box.scss
@@ -11,7 +11,6 @@
   z-index: $layer-8;
   height: 50px;
   min-width: 134px;
-  margin-top: 1em;
   border-collapse: collapse;
   @include box-sizing(border-box);
   @include rounded-except(none);
@@ -21,6 +20,7 @@
   font-weight: bold;
   vertical-align: middle;
   font-family: $font_sans_serif;
+  margin-left: 45px;
 
   cursor: pointer;
 

--- a/app/assets/stylesheets/components/_input-search.scss
+++ b/app/assets/stylesheets/components/_input-search.scss
@@ -197,6 +197,27 @@ input.search-input:-webkit-autofill {
   -webkit-text-fill-color: $greyscale_dark !important;
 }
 
+.home-page-search-container {
+  display: flex;                  /* establish flex container */
+  flex-direction: row;            /* default value; can be omitted */
+  flex-wrap: nowrap;              /* default value; can be omitted */
+  justify-content: space-between; /* switched from default (flex-start, see below) */
+}
+
+.category_search_select{
+  font-style: normal;
+  color: $grey;
+  width: 100%;
+  max-width: 180px;
+  height: 50px;
+  vertical-align: middle;
+  font-family: $font_sans_serif;
+  font-size: $font_size_110;
+  border-collapse: collapse;
+  @include box-sizing(border-box);
+  @include rounded-except(none);
+}
+
 
 .input-search-filter {
   @include input-placeholder(rgba($grey, 0.6), regular);

--- a/app/assets/stylesheets/components/_input-search.scss
+++ b/app/assets/stylesheets/components/_input-search.scss
@@ -214,6 +214,7 @@ input.search-input:-webkit-autofill {
   font-family: $font_sans_serif;
   font-size: $font_size_110;
   border-collapse: collapse;
+  padding-left: 10px;
   @include box-sizing(border-box);
   @include rounded-except(none);
 }

--- a/app/assets/stylesheets/components/_input-search.scss
+++ b/app/assets/stylesheets/components/_input-search.scss
@@ -208,7 +208,7 @@ input.search-input:-webkit-autofill {
   font-style: normal;
   color: $grey;
   width: 100%;
-  max-width: 180px;
+  min-width: 180px;
   height: 50px;
   vertical-align: middle;
   font-family: $font_sans_serif;

--- a/app/helpers/filter_categories_helper.rb
+++ b/app/helpers/filter_categories_helper.rb
@@ -36,6 +36,10 @@ module FilterCategoriesHelper
     cats.sort_by { |e| e.first[:filter_priority] }
   end
 
+  def categories_for_select
+    categories ||= Ohanakapa.categories.select { |cat| cat[:depth] == 0  and cat[:type] == "service" }.flatten.uniq.map(&:name)
+  end
+
   def parent_filter(category)
     cat_family = category[:taxonomy_id].split('-').first
     @filter_categories.select { |c| c[:taxonomy_id].include?(cat_family) && c[:filter_parent] }.first

--- a/app/helpers/filter_categories_helper.rb
+++ b/app/helpers/filter_categories_helper.rb
@@ -37,7 +37,7 @@ module FilterCategoriesHelper
   end
 
   def categories_for_select
-    categories ||= Ohanakapa.categories.select { |cat| cat[:depth] == 0  and cat[:type] == "service" }.flatten.uniq.map(&:name)
+    categories ||= Ohanakapa.categories.select { |cat| cat[:depth] == 0  and cat[:type] == "service" }.flatten.uniq.map{ |cat| [cat.name, cat.id]}
   end
 
   def parent_filter(category)

--- a/app/views/component/search/_box.html.haml
+++ b/app/views/component/search/_box.html.haml
@@ -5,7 +5,7 @@
         = label_tag 'prompt', t('labels.homepage_prompt')
         %section#keyword-search-box.search-box.home-page-search-container
           %div
-            = select_tag :category, options_for_select(categories_for_select), include_blank: 'All', class: "category_search_select"
+            = select_tag :categories, options_for_select(categories_for_select), include_blank: 'All', class: "category_search_select"
           %div
             .input-search-big.keyword
               = search_field_tag :keyword, params[:keyword], placeholder: t('placeholders.homepage_keyword_search'), tabindex: 1, class: 'search-input'

--- a/app/views/component/search/_box.html.haml
+++ b/app/views/component/search/_box.html.haml
@@ -5,7 +5,7 @@
         = label_tag 'prompt', t('labels.homepage_prompt')
         %section#keyword-search-box.search-box.home-page-search-container
           %div
-            = select_tag :category, options_for_select(filter_categories), include_blank: 'All', class: "category_search_select"
+            = select_tag :category, options_for_select(categories_for_select), include_blank: 'All', class: "category_search_select"
           %div
             .input-search-big.keyword
               = search_field_tag :keyword, params[:keyword], placeholder: t('placeholders.homepage_keyword_search'), tabindex: 1, class: 'search-input'

--- a/app/views/component/search/_box.html.haml
+++ b/app/views/component/search/_box.html.haml
@@ -4,7 +4,6 @@
       %div.search-form
         = label_tag 'prompt', t('labels.homepage_prompt')
         %section#keyword-search-box.search-box
-          = label_tag 'keyword', t('labels.homepage_search')
           .input-search-big.keyword
             = search_field_tag :keyword, params[:keyword], placeholder: t('placeholders.homepage_keyword_search'), tabindex: 1, class: 'search-input'
         = button_tag(type: 'submit', name: nil, id: 'button-search', class: 'landing-button-icon', title: 'Search', tabindex: 3) do

--- a/app/views/component/search/_box.html.haml
+++ b/app/views/component/search/_box.html.haml
@@ -3,9 +3,13 @@
     %div
       %div.search-form
         = label_tag 'prompt', t('labels.homepage_prompt')
-        %section#keyword-search-box.search-box
-          .input-search-big.keyword
-            = search_field_tag :keyword, params[:keyword], placeholder: t('placeholders.homepage_keyword_search'), tabindex: 1, class: 'search-input'
-        = button_tag(type: 'submit', name: nil, id: 'button-search', class: 'landing-button-icon', title: 'Search', tabindex: 3) do
-          %span
-            = t('buttons.homepage_search')
+        %section#keyword-search-box.search-box.home-page-search-container
+          %div
+            = select_tag :category, options_for_select(filter_categories), include_blank: 'All', class: "category_search_select"
+          %div
+            .input-search-big.keyword
+              = search_field_tag :keyword, params[:keyword], placeholder: t('placeholders.homepage_keyword_search'), tabindex: 1, class: 'search-input'
+          %div  
+            = button_tag(type: 'submit', name: nil, id: 'button-search', class: 'landing-button-icon', title: 'Search', tabindex: 3) do
+              %span
+                = t('buttons.homepage_search')

--- a/app/views/component/search/_box.html.haml
+++ b/app/views/component/search/_box.html.haml
@@ -7,11 +7,6 @@
           = label_tag 'keyword', t('labels.homepage_search')
           .input-search-big.keyword
             = search_field_tag :keyword, params[:keyword], placeholder: t('placeholders.homepage_keyword_search'), tabindex: 1, class: 'search-input'
-        %section#location-search-box.search-box
-          = hidden_field_tag 'location'
-          = label_tag 'keyword', t('labels.homepage_location_search')
-          .input-search-big.location
-            = search_field_tag :location, params[:location], placeholder: t('placeholders.homepage_location_search'), tabindex: 2, class: 'search-input'
         = button_tag(type: 'submit', name: nil, id: 'button-search', class: 'landing-button-icon', title: 'Search', tabindex: 3) do
           %span
             = t('buttons.homepage_search')

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -72,7 +72,6 @@ en:
     address_search: 'Zipcode'
     agency_search: 'Organization Name'
     homepage_prompt: 'What are you looking for today?'
-    homepage_search: 'I need'
     filters:
       filter_by_category: 'Filter by Category'
     topic_prompt: 'Choose a topic below to begin a search'

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -73,7 +73,6 @@ en:
     agency_search: 'Organization Name'
     homepage_prompt: 'What are you looking for today?'
     homepage_search: 'I need'
-    homepage_location_search: 'near'
     filters:
       filter_by_category: 'Filter by Category'
     topic_prompt: 'Choose a topic below to begin a search'
@@ -106,7 +105,6 @@ en:
     agency_search: 'full or partial name'
     keyword_search: 'service or topic'
     homepage_keyword_search: 'service or topic'
-    homepage_location_search: 'zip code'
     results_page_keyword_search: 'search for...'
 
   service_fields:


### PR DESCRIPTION
**Zube reference:** 

https://zube.io/smartlogic/bchd/c/204

https://zube.io/smartlogic/bchd/c/204

**Requirements:** 
Change the home page: 
- Remove "I need" 
- Remove "Near" and Zip Code input field 
- Add Drop down menu including the categories with "All" option as default
- match the following design: 

![image](https://user-images.githubusercontent.com/1304609/103393039-b7b9a180-4aee-11eb-9e29-03459baff57e.png)

![Screen Shot 2020-12-30 at 10 04 46 PM](https://user-images.githubusercontent.com/1304609/103393065-c011dc80-4aee-11eb-80b0-51a433e843ea.png)

**Make sure that the Category chosen is considered by API and is affecting the results:** 

![Screen Shot 2020-12-30 at 10 20 22 PM](https://user-images.githubusercontent.com/1304609/103393099-f7808900-4aee-11eb-8d40-f566dae409d5.png)

![Screen Shot 2020-12-30 at 10 15 18 PM](https://user-images.githubusercontent.com/1304609/103393293-ea17ce80-4aef-11eb-8db2-2e5ef19a761d.png)



