### PR TITLE
fixing tab on charmcare homepage 

### DIFF
--- a/app/views/component/search/_box.html.haml
+++ b/app/views/component/search/_box.html.haml
@@ -8,8 +8,8 @@
             = select_tag :categories, options_for_select(categories_for_select), include_blank: 'All', class: "category_search_select"
           %div
             .input-search-big.keyword
-              = search_field_tag :keyword, params[:keyword], placeholder: t('placeholders.homepage_keyword_search'), tabindex: 1, class: 'search-input'
+              = search_field_tag :keyword, params[:keyword], placeholder: t('placeholders.homepage_keyword_search'), class: 'search-input'
           %div  
-            = button_tag(type: 'submit', name: nil, id: 'button-search', class: 'landing-button-icon', title: 'Search', tabindex: 3) do
+            = button_tag(type: 'submit', name: nil, id: 'button-search', class: 'landing-button-icon', title: 'Search') do
               %span
                 = t('buttons.homepage_search')


### PR DESCRIPTION
fixed how the tab button highlights elements on the charmcare homepage for accessibility purposes 