### PR TITLE
[Zube 261] Add link "Register for a Vaccination Appointment" on the main page

### DIFF
--- a/app/assets/stylesheets/components/_box.scss
+++ b/app/assets/stylesheets/components/_box.scss
@@ -7,6 +7,17 @@
   font-weight: bold;
 }
 
+.vaccination-link {
+  font-family: $font_sans_serif;
+  font-weight: bold;
+  font-size: $font_size_110;
+  color: $white;
+}
+
+.vaccination-link-container {
+  margin-top:7%;
+}
+
 .landing-button-icon {
   display: inline-block;
   z-index: $layer-8;

--- a/app/views/component/search/_box.html.haml
+++ b/app/views/component/search/_box.html.haml
@@ -16,3 +16,7 @@
             = button_tag(type: 'submit', name: nil, id: 'button-search', class: 'landing-button-icon', title: 'Search') do
               %span
                 = t('buttons.homepage_search')
+        %div.vaccination-link-container
+          %a.vaccination-link{ :href => "https://covax.baltimorecity.gov/", :title => t('labels.vaccination-link-text') }
+            %strong
+              = t('labels.vaccination-link-text')

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -77,6 +77,7 @@ en:
       category_filter_title: 'Services Provided'
       filters_menu_title: 'Refine your search'
     topic_prompt: 'Choose a topic below to begin a search'
+    vaccination-link-text: 'Register for a Vaccination Appointment'
 
   location_fields:
     accessibility: 'Accessibility'


### PR DESCRIPTION
## Description
Charmcare team requested to add a link on the main page to redirect users to an outside page using the text "Register for a Vaccination Appointment" 

Zube Reference:
[Zube 261](https://zube.io/smartlogic/bchd/c/261)

Design Reference: 
https://www.figma.com/file/tEq3lKkQxJiwwXbZg2XpG5/Untitled?node-id=101%3A4

# Print Screens
<img width="1531" alt="Screen Shot 2021-05-10 at 4 33 03 PM" src="https://user-images.githubusercontent.com/1304609/117721596-0f0f0300-b1ae-11eb-8d83-30040e456554.png">
