### PR TITLE
subcategories expanded by default

### DIFF
--- a/app/javascript/app/search/filter/search-filters.js
+++ b/app/javascript/app/search/filter/search-filters.js
@@ -114,7 +114,7 @@ function _updateSubCategories(){
   
           var container = document.createElement("div");
           container.classList.add("filter-category-item");
-          container.classList.add("hide");
+          // container.classList.add("hide");
   
           var checkbox = document.createElement('input'); 
           checkbox.type = "checkbox";  

--- a/app/views/component/search/_filters.html.haml
+++ b/app/views/component/search/_filters.html.haml
@@ -5,7 +5,7 @@
   %hr
 
 - if @main_category_selected_name == ""
-  %div#parent-category.parent-category-label-container{ tabindex: "0", role: "button", aria: { label: 'Select a Topic from above to display additional filters.', expanded: 'false'}}
+  %div#parent-category.parent-category-label-container{ tabindex: "0", role: "button", aria: { label: 'Select a Topic from above to display additional filters.', expanded: 'true'}}
     %legend
       %span#subcategoriesFilterTitle.filter-description-label
         = "Select a Topic from above to display additional filters."
@@ -14,7 +14,7 @@
   %fieldset#subcategoriesList
   
 - else
-  %div#parent-category.parent-category-label-container.hoverable{ tabindex: "0", role: "button", aria: { label: 'Click enter to expand and collapse filters', expanded: 'false'}}
+  %div#parent-category.parent-category-label-container.hoverable{ tabindex: "0", role: "button", aria: { label: 'Click enter to expand and collapse filters', expanded: 'true'}}
     %legend
       %span#subcategoriesFilterTitle.parent-category-label
         = "#{category_filters_title(@main_category_selected_name)}"


### PR DESCRIPTION
> This PR allows subcategories to be open by default when selecting a category

[Zube 258](https://zube.io/smartlogic/bchd/c/258)

### Reviewer Steps

1. Go to: http://localhost:3000/locations
2. Select Category On The Left Panel
3. Subcategory Menu Should Be Expanded By Default



### How did you test this?
<!--- manual -->
