### PR TITLE
Use the new style of redirecting back (from rails 5)

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -18,20 +18,10 @@ class ApplicationController < ActionController::Base
   end
 
   def render_bad_search
-    redirect_to path, alert: t('errors.bad_search')
+    redirect_back fallback_location: root_path, alert: t('errors.bad_search')
   end
 
   def render_not_found
-    redirect_to path, alert: t('errors.not_found')
-  end
-
-  def path
-    referer = request.env['HTTP_REFERER']
-    uri = request.env['REQUEST_URI']
-    if referer.present? && referer != uri
-      :back
-    else
-      root_path
-    end
+    redirect_back fallback_location: root_path, alert: t('errors.not_found')
   end
 end


### PR DESCRIPTION
This should prevent the `back_url` error we've been seeing in sentry.

See this blog post https://www.bigbinary.com/blog/rails-5-improves-redirect_to_back-with-redirect-back