### PR TITLE
Category id bug

### DIFF
--- a/app/controllers/locations_controller.rb
+++ b/app/controllers/locations_controller.rb
@@ -1,6 +1,5 @@
 class LocationsController < ApplicationController
   include Cacheable
-  
 
   def index
     # To enable Google Translation of keywords,
@@ -12,9 +11,11 @@ class LocationsController < ApplicationController
     @main_category_selected_id = ""
 
     unless params[:main_category].nil? || params[:main_category].empty?
-      @main_category_selected_name = params[:main_category]
-      @main_category_selected_id = helpers.get_category_id_by_name(@main_category_selected_name)
-      params[:main_category_id] = @main_category_selected_id
+      if validate_category
+        @main_category_selected_name = params[:main_category]
+        @main_category_selected_id = helpers.get_category_id_by_name(@main_category_selected_name)
+        params[:main_category_id] = @main_category_selected_id
+      end  
     end
     if params["categories"] and @main_category_selected_id != ""
       params["categories_ids"] = helpers.get_subcategories_ids(params["categories"], @main_category_selected_id)
@@ -83,6 +84,10 @@ class LocationsController < ApplicationController
     respond_to do |format|
       format.js { render :json => {sub_cat_array: sub_cat_array, category_title: helpers.category_filters_title(category_name)}.to_json }
     end
+  end
+
+  def validate_category
+    return helpers.main_categories_array.map{|row| row[0] }.include?(params[:main_category])
   end
 
 end


### PR DESCRIPTION
intended to fix [this sentry error](https://sentry.io/organizations/smartlogic/issues/2252484814/?project=5339670&query=is%3Aunresolved)

this bug is caused by invalid main_category params. Some errors look like they could be caused by faulty front end code (for example main_category = Food'[0]) while others look more like user error (for example main_category = https//www.google.com)

I added validation so that if the controller receives a main category param that isn't in its permitted list of categories it will default to showing all categories (the @main_category_selected_name and @main_category_selected_id variables remain empty strings)